### PR TITLE
Automate Vercel deploys; add loading screen, cyber background, and harden auth/visitor tracking

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,26 @@
+name: Vercel Deploy
+
+on:
+  push:
+    branches:
+      - work
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: "--prod"

--- a/api/collect_data.php
+++ b/api/collect_data.php
@@ -99,7 +99,65 @@ if (isset($result['error'])) {
 // Armazena dados na sessão
 $_SESSION['visitor_info'] = $visitor_info;
 
-// Redireciona para index.php
-header("Location: /api/index.php");
-exit();
+// Exibe uma tela de carregamento antes de redirecionar para o login
+$redirect_url = "/api/index.php";
 ?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="2;url=<?php echo htmlspecialchars($redirect_url, ENT_QUOTES); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Carregando...</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: Arial, sans-serif;
+            background: radial-gradient(circle at top, #1a1a2e 0%, #0f3460 50%, #0b132b 100%);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+        .loader {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 16px;
+            text-align: center;
+        }
+        .spinner {
+            width: 64px;
+            height: 64px;
+            border: 6px solid rgba(255, 255, 255, 0.2);
+            border-top-color: #4caf50;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        .logo {
+            width: 80px;
+            height: auto;
+        }
+        .message {
+            font-size: 1rem;
+            letter-spacing: 0.5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="loader">
+        <img src="/api/static/dwtyay_favicon.gif" alt="Nick Dwtyay" class="logo">
+        <div class="spinner" aria-label="Carregando"></div>
+        <div class="message">Carregando, aguarde...</div>
+    </div>
+    <script>
+        setTimeout(() => {
+            window.location.href = <?php echo json_encode($redirect_url); ?>;
+        }, 2000);
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,9 @@
 
 <script>
     function redirect() {
-      window.location.href = "api/index.php; // Substitua "Home.html" pelo URL da sua página inicial
+      if (!window.location.pathname.startsWith('/api/')) {
+        window.location.href = "/api/index.php";
+      }
     }
 
     setTimeout(redirect, 30000); // Tempo em milissegundos, 30 segundos = 30000 milissegundos
@@ -78,8 +80,51 @@
 
   gtag('config', 'G-5F4Q111FPX');
 </script>
+<style>
+  .cyber-bg {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(circle at 20% 20%, rgba(76, 175, 80, 0.12), transparent 35%),
+      radial-gradient(circle at 80% 30%, rgba(0, 212, 255, 0.12), transparent 40%),
+      linear-gradient(120deg, rgba(10, 15, 30, 0.85), rgba(7, 20, 40, 0.9));
+  }
+  .cyber-bg::before,
+  .cyber-bg::after {
+    content: "";
+    position: absolute;
+    inset: -50%;
+    background-image:
+      linear-gradient(rgba(0, 212, 255, 0.15) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(0, 212, 255, 0.08) 1px, transparent 1px);
+    background-size: 80px 80px;
+    animation: grid-drift 18s linear infinite;
+    opacity: 0.35;
+  }
+  .cyber-bg::after {
+    background-size: 160px 160px;
+    animation-duration: 28s;
+    opacity: 0.2;
+  }
+  @keyframes grid-drift {
+    0% { transform: translate3d(0, 0, 0); }
+    100% { transform: translate3d(120px, 80px, 0); }
+  }
+  body > *:not(.cyber-bg) {
+    position: relative;
+    z-index: 1;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .cyber-bg::before,
+    .cyber-bg::after {
+      animation: none;
+    }
+  }
+</style>
 </head>
-<body><script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1922092235705770"
+<body><div class="cyber-bg" aria-hidden="true"></div><script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1922092235705770"
      crossorigin="anonymous"></script>
 
 


### PR DESCRIPTION
### Motivation
- Automate production deployments to Vercel and streamline the public site UX. 
- Prevent redirect loops and provide a short branded loading handoff into the login flow. 
- Harden authentication/session handling and make visitor IP/third‑party lookups resilient when env keys are missing. 

### Description
- Added a GitHub Actions workflow `.github/workflows/vercel-deploy.yml` to deploy to Vercel on pushes to `work`/`main` or via `workflow_dispatch`, using `secrets.VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID`.
- Replaced immediate redirect in `api/collect_data.php` with a small loading HTML page (2s auto-redirect) and spinner, and persisted `$_SESSION['visitor_info']` after initial save.
- Strengthened login flow in `api/index.php` by validating emails with `filter_var`, calling `session_regenerate_id(true)` on success, making the `secure` cookie flag conditional on development/TLS detection, improving real IP extraction with `HTTP_X_FORWARDED_FOR` fallback and `FILTER_VALIDATE_IP`, defaulting `HTTP_USER_AGENT` when missing, and guarding external lookups (ipinfo/IPQualityScore/ProxyCheck) to only run when corresponding env keys are present.
- Added a layered animated cyber background and styles to `index.html` and inserted `<div class="cyber-bg" aria-hidden="true"></div>` so content stays on top, and fixed the client-side redirect guard to skip redirect when the path starts with `/api/` and updated the client-side visitor updater to POST to `/api/update_visitor.php`.

### Testing
- No automated tests were executed in this rollout; the CI workflow (`.github/workflows/vercel-deploy.yml`) is configuration-only and has not been run yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982bc0d5ad48324a9ac888a128d0ad1)